### PR TITLE
Set use ytdlp false

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,4 +43,4 @@ You can run this script with the optional flags. For example:
 python ta_migration_helper.py -s /path/to/custom/directory -Y -S 5 -M
 ```
 
-This would set the source directory to `/path/to/custom/directory`, disable YouTube calls via `yt-dlp`, set the sleep time to 5 seconds between YouTube calls, and enable migration.
+This would set the source directory to `/path/to/custom/directory`, enable YouTube calls via `yt-dlp`, set the sleep time to 5 seconds between YouTube calls, and enable migration.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Migration helper for [TubeArchivist](https://github.com/tubearchivist/tubearchiv
 Argument | Flag | Default | Purpose
 :--- | :---: | :---: | :---
 `SOURCE_DIR` | -d | `/youtube` | The source directory that will be searched for videos that need to be migrated. This can be used to specify an individual folder instead of the entire `/youtube` directory[^1].
-`USE_YTDLP` | -Y | `True` | Allows the user to disable calls to YouTube via `yt-dlp`. This will not allow any calls to YouTube and will instead only search ElasticSearch. 
+`USE_YTDLP` | -Y | `False` | Allows the user to enable calls to YouTube via `yt-dlp`. Default behavious is to not allow any calls to YouTube and instead only search within ElasticSearch. 
 `YTDLP_SLEEP` | -s | `3` | Number of seconds to wait between each call to YouTube when using `yt-dlp`. Value will not be used if `USE_YTDLP` is set to `False`.
 `PERFORM_MIGRATION` | -M | `False` | If set to `False`, this will perform a review of what files need to be migrated and why. If set to `True`, this will attempt to migrate all files[^2]. 
 

--- a/ta_migration_helper.py
+++ b/ta_migration_helper.py
@@ -24,7 +24,7 @@ class FakeLogger(object):
 
 def parse_args():
     default_source = "/youtube"
-    default_use_ytdlp = True
+    default_use_ytdlp = False
     default_ytdlp_sleep = 3
     default_perform_migration = False
     parser = argparse.ArgumentParser(description="TA Migration Helper Script")


### PR DESCRIPTION
Since it didn't matter if the `-Y` flag was set (it was `True` everytime), I tried setting that to default `False`, and users can set it to `True` if needed.

Of course feel free to discard the pull request if this is not your intended way.